### PR TITLE
Add: check `location_area_encounters` index exists

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -646,7 +646,7 @@ class Client
         $data = $callback($url);
 
         // TODO: Remove this ugly hack once PokéAPI is fixed
-        if ($uri === Pokemon::POKEAPI_ENDPOINT) {
+        if ($uri === Pokemon::POKEAPI_ENDPOINT && isset($data['location_area_encounters'])) {
             $data['location_area_encounters'] = $this->fixEncounters($data['location_area_encounters']);
         }
 


### PR DESCRIPTION
Fixes an issue where using `$client->pokemon('?limit=300&offset=0');` results in a notice and then fatal error because `$data` doesn't contain `location_area_encounters`